### PR TITLE
cell_from_id: fix access to bounds properties

### DIFF
--- a/src/majortom_eg/MajorTom.py
+++ b/src/majortom_eg/MajorTom.py
@@ -101,10 +101,10 @@ class MajorTomGrid:
             raise ValueError("Cell ID must be exactly 11 characters")
 
         bounds = geohash.bounds(cell_id)
-        buffer_size = 0.0001 * self.D if buffer else 0
-        p = box(bounds['w'], bounds['s'], bounds['e'], bounds['n'])
+        p = box(bounds.sw[1],bounds.sw[0],bounds.ne[1],bounds.ne[0])
 
         if buffer:
+            buffer_size = 0.0001 * self.D
             p = p.buffer(buffer_size)
 
         candidates = list(self.generate_grid_cells(p))


### PR DESCRIPTION
On the latest of main ( e21099888bd9a410e0c915c7c6b525d395c4f386 ) , I am getting: 

```
>>> from src.majortom_eg.MajorTom import MajorTomGrid,GridCell
>>> grid = MajorTomGrid(d=320, overlap=True)
>>> grid.cell_from_id('dr19n8kep4c')
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    grid.cell_from_id('dr19n8kep4c')
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/losi/prj/lgnd/majortom/src/majortom_eg/MajorTom.py", line 105, in cell_from_id
    p = box(bounds['w'], bounds['s'], bounds['e'], bounds['n'])
            ~~~~~~^^^^^
TypeError: tuple indices must be integers or slices, not str
```

the referenced `bounds` keys don't exist. 

Restoring to the previous use of `bounds` addresses the issue.