### PR TITLE
Align grid with ESA reference implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "majortom_eg"
-version = "0.3.0"
+version = "1.0.0"
 description = 'Implementation of the ESA MajorTom grid system'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/majortom_eg/MajorTom.py
+++ b/src/majortom_eg/MajorTom.py
@@ -23,13 +23,14 @@ class MajorTomGrid:
         self.earth_radius = 6378137
         self.overlap = overlap
         self.row_count = max(2, np.ceil(np.pi * self.earth_radius / self.D))
-        self.lat_spacing = self.get_lat_spacing()  # Calculate lat_spacing once
+        self.lat_spacing = self.get_lat_spacing()
+        self._lat_offset = self.lat_spacing / 2 if int(self.row_count) % 2 else 0
 
     def get_lat_spacing(self):
         return min(180 / self.row_count, 89)
 
     def get_row_lat(self, row_idx):
-        return -90 + row_idx * self.lat_spacing
+        return -90 + self._lat_offset + row_idx * self.lat_spacing
 
     def get_lon_spacing(self, lat):
         lat_rad = np.radians(min(max(lat, -89), 89))
@@ -37,17 +38,21 @@ class MajorTomGrid:
         n_cols = int(np.ceil(circumference / self.D))
         return 360 / max(n_cols, 1)
 
+    def get_lon_offset(self, lon_spacing):
+        n_cols = round(360 / lon_spacing) if lon_spacing > 0 else 0
+        return lon_spacing / 2 if n_cols % 2 else 0
+
+    def get_col_lon(self, col_idx, lon_spacing, lon_offset):
+        return -180 + lon_offset + col_idx * lon_spacing
+
     def generate_grid_cells(self, polygon):
         min_lon, min_lat, max_lon, max_lat = polygon.bounds
-        # Handle date line crossing
         if min_lon > max_lon:
             max_lon += 360
 
-        # --- Key Change 1: More Precise Row/Col Ranges ---
-        start_row = int(np.floor((min_lat + 90) / self.lat_spacing))
-        end_row = int(np.ceil((max_lat + 90) / self.lat_spacing))
-        
-        # Adjust row range
+        start_row = int(np.floor((min_lat + 90 - self._lat_offset) / self.lat_spacing))
+        end_row = int(np.ceil((max_lat + 90 - self._lat_offset) / self.lat_spacing))
+
         while self.get_row_lat(start_row) > min_lat + 1e-10:
             start_row -= 1
         while self.get_row_lat(end_row) < max_lat - 1e-10:
@@ -56,19 +61,18 @@ class MajorTomGrid:
         for row_idx in range(start_row, end_row + 1):
             lat = self.get_row_lat(row_idx)
             lon_spacing = self.get_lon_spacing(lat)
+            lon_offset = self.get_lon_offset(lon_spacing)
 
-            start_col = int(np.floor((min_lon + 180) / lon_spacing))
-            end_col = int(np.ceil((max_lon + 180) / lon_spacing))
-            
-            # Adjust column range
-            while -180 + start_col * lon_spacing > min_lon + 1e-10:
+            start_col = int(np.floor((min_lon + 180 - lon_offset) / lon_spacing))
+            end_col = int(np.ceil((max_lon + 180 - lon_offset) / lon_spacing))
+
+            while self.get_col_lon(start_col, lon_spacing, lon_offset) > min_lon + 1e-10:
                 start_col -= 1
-            while -180 + end_col * lon_spacing < max_lon - 1e-10:
+            while self.get_col_lon(end_col, lon_spacing, lon_offset) < max_lon - 1e-10:
                 end_col += 1
 
             for col_idx in range(start_col, end_col + 1):
-                lon = -180 + col_idx * lon_spacing
-                # Create the primary grid cell polygon
+                lon = self.get_col_lon(col_idx, lon_spacing, lon_offset)
                 primary_cell_polygon = Polygon([
                     [lon, lat],
                     [lon + lon_spacing, lat],
@@ -77,7 +81,6 @@ class MajorTomGrid:
                 ])
 
                 if self.overlap:
-                    # Create overlapping cell with 50% overlap
                     overlap_lon = lon + lon_spacing/2
                     overlap_lat = lat + self.lat_spacing/2
                     overlap_cell_polygon = Polygon([
@@ -86,7 +89,7 @@ class MajorTomGrid:
                         [overlap_lon + lon_spacing, overlap_lat + self.lat_spacing],
                         [overlap_lon, overlap_lat + self.lat_spacing]
                     ])
-                    
+
                     if primary_cell_polygon.intersects(polygon):
                         yield GridCell(primary_cell_polygon, is_primary=True)
                     if overlap_cell_polygon.intersects(polygon):
@@ -107,14 +110,15 @@ class MajorTomGrid:
 
         half_lat = self.lat_spacing / 2
         for row_offset in (-1, 0, 1):
-            row_idx = int(np.floor((center_lat + 90) / self.lat_spacing)) + row_offset
+            row_idx = int(np.floor((center_lat + 90 - self._lat_offset) / self.lat_spacing)) + row_offset
             row_lat = self.get_row_lat(row_idx)
             lon_spacing = self.get_lon_spacing(row_lat)
+            lon_offset = self.get_lon_offset(lon_spacing)
             half_lon = lon_spacing / 2
 
             for col_offset in (-1, 0, 1):
-                col_idx = int(np.floor((center_lon + 180) / lon_spacing)) + col_offset
-                cell_lon = -180 + col_idx * lon_spacing
+                col_idx = int(np.floor((center_lon + 180 - lon_offset) / lon_spacing)) + col_offset
+                cell_lon = self.get_col_lon(col_idx, lon_spacing, lon_offset)
 
                 primary = Polygon([
                     [cell_lon, row_lat],
@@ -140,3 +144,30 @@ class MajorTomGrid:
                         return overlap_cell
 
         raise ValueError(f"No cell found with ID {cell_id}")
+
+    def migrate_cell_id(self, old_id: str) -> GridCell:
+        """Map a cell ID from a prior grid version to the current grid.
+
+        Decodes the geohash to recover the approximate centroid, then returns
+        the current-grid cell that contains that point.
+        """
+        search_id = old_id[:11] if len(old_id) > 11 else old_id
+        if len(search_id) != 11:
+            raise ValueError("Cell ID must be at least 11 characters")
+
+        lat, lon = (float(v) for v in geohash.decode(search_id))
+
+        row_idx = int(np.floor((lat + 90 - self._lat_offset) / self.lat_spacing))
+        row_lat = self.get_row_lat(row_idx)
+        lon_spacing = self.get_lon_spacing(row_lat)
+        lon_offset = self.get_lon_offset(lon_spacing)
+        col_idx = int(np.floor((lon + 180 - lon_offset) / lon_spacing))
+        cell_lon = self.get_col_lon(col_idx, lon_spacing, lon_offset)
+
+        cell_polygon = Polygon([
+            [cell_lon, row_lat],
+            [cell_lon + lon_spacing, row_lat],
+            [cell_lon + lon_spacing, row_lat + self.lat_spacing],
+            [cell_lon, row_lat + self.lat_spacing],
+        ])
+        return GridCell(cell_polygon, is_primary=True)

--- a/src/majortom_eg/__about__.py
+++ b/src/majortom_eg/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present Earth Genome <info@earthgenome.org>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.3.0"
+__version__ = "1.0.0"

--- a/tests/test_major_tom_grid.py
+++ b/tests/test_major_tom_grid.py
@@ -459,7 +459,7 @@ class TestMajorTomGrid(unittest.TestCase):
 
         cells = list(self.grid.generate_grid_cells(test_poly))
         # There should be at least one cell intersecting this polygon
-        self.assertTrue(len(cells) == 222, "Should generate 222 cells")
+        self.assertTrue(len(cells) == 225, "Should generate 225 cells")
         # Check that all returned cells intersect the original polygon
         for cell in cells:
             self.assertTrue(cell.geom.intersects(test_poly), "All returned cells should intersect the polygon")
@@ -518,6 +518,113 @@ class TestMajorTomGrid(unittest.TestCase):
         self.assertIsNotNone(cell)
         self.assertEqual(cell.id(), '6r32gxpn0w4')
         self.assertFalse(cell.is_primary)
+
+class TestESACompatibility(unittest.TestCase):
+    """Verify grid alignment matches ESA's linspace+mod reference implementation."""
+
+    EARTH_RADIUS_KM = 6378.137
+
+    def _esa_latitudes(self, dist_km):
+        import math
+        num_divisions = math.ceil(math.pi * self.EARTH_RADIUS_KM / dist_km)
+        import numpy as np
+        lats = np.linspace(-90, 90, num_divisions + 1)[:-1]
+        lats = np.mod(lats, 180) - 90
+        return np.sort(lats)
+
+    def _esa_longitudes(self, lat, dist_km):
+        import math, numpy as np
+        circumference = 2 * math.pi * self.EARTH_RADIUS_KM * math.cos(lat * math.pi / 180)
+        num_divisions = math.ceil(circumference / dist_km)
+        lons = np.linspace(-180, 180, num_divisions + 1)[:-1]
+        lons = np.mod(lons, 360) - 180
+        return np.sort(lons)
+
+    def _eg_latitudes(self, grid):
+        import numpy as np
+        return np.array([grid.get_row_lat(i) for i in range(int(grid.row_count))])
+
+    def _eg_longitudes(self, grid, lat):
+        import numpy as np
+        lon_spacing = grid.get_lon_spacing(lat)
+        lon_offset = grid.get_lon_offset(lon_spacing)
+        n_cols = int(np.ceil(
+            2 * np.pi * grid.earth_radius * np.cos(np.radians(min(max(lat, -89), 89))) / grid.D
+        ))
+        return np.array([grid.get_col_lon(i, lon_spacing, lon_offset) for i in range(n_cols)])
+
+    def test_latitude_alignment(self):
+        import numpy as np
+        for dist_km in [5, 10, 50, 100]:
+            dist_m = dist_km * 1000
+            grid = MajorTomGrid(d=dist_m, overlap=False)
+            esa_lats = self._esa_latitudes(dist_km)
+            eg_lats = self._eg_latitudes(grid)
+            self.assertEqual(len(esa_lats), len(eg_lats),
+                f"dist={dist_km}km: latitude count mismatch ({len(esa_lats)} vs {len(eg_lats)})")
+            np.testing.assert_allclose(eg_lats, esa_lats, atol=1e-10,
+                err_msg=f"dist={dist_km}km: latitude values differ")
+
+    def test_longitude_alignment(self):
+        import numpy as np
+        for dist_km in [5, 10, 50, 100]:
+            dist_m = dist_km * 1000
+            grid = MajorTomGrid(d=dist_m, overlap=False)
+            for test_lat in [0.0, 30.0, 45.0, 60.0]:
+                esa_lons = self._esa_longitudes(test_lat, dist_km)
+                eg_lons = self._eg_longitudes(grid, test_lat)
+                self.assertEqual(len(esa_lons), len(eg_lons),
+                    f"dist={dist_km}km, lat={test_lat}: longitude count mismatch")
+                np.testing.assert_allclose(eg_lons, esa_lons, atol=1e-10,
+                    err_msg=f"dist={dist_km}km, lat={test_lat}: longitude values differ")
+
+    def test_equator_on_grid_line(self):
+        for dist_km in [5, 7, 10, 13, 50, 100]:
+            dist_m = dist_km * 1000
+            grid = MajorTomGrid(d=dist_m, overlap=False)
+            lats = self._eg_latitudes(grid)
+            self.assertIn(0.0, lats,
+                f"dist={dist_km}km: equator (0.0) should be a grid line")
+
+    def test_prime_meridian_on_grid_line(self):
+        for dist_km in [5, 7, 10, 13, 50, 100]:
+            dist_m = dist_km * 1000
+            grid = MajorTomGrid(d=dist_m, overlap=False)
+            for test_lat in [0.0, 30.0, 60.0]:
+                lons = self._eg_longitudes(grid, test_lat)
+                self.assertIn(0.0, lons,
+                    f"dist={dist_km}km, lat={test_lat}: prime meridian (0.0) should be a grid line")
+
+
+class TestMigrateCellId(unittest.TestCase):
+
+    def test_migrated_cell_contains_old_centroid(self):
+        from geolib import geohash as gh
+        grid = MajorTomGrid(d=320, overlap=True)
+        old_ids = ["dr18zj1ntew", "dr19n8zgg4e", "s000003037z", "6r32gxpn0w4"]
+        for old_id in old_ids:
+            new_cell = grid.migrate_cell_id(old_id)
+            lat, lon = gh.decode(old_id)
+            self.assertTrue(
+                new_cell.geom.contains(Point(lon, lat)),
+                f"New cell should contain decoded centroid of old ID {old_id}"
+            )
+
+    def test_migrated_cell_is_primary(self):
+        grid = MajorTomGrid(d=320, overlap=True)
+        new_cell = grid.migrate_cell_id("dr18zj1ntew")
+        self.assertTrue(new_cell.is_primary)
+
+    def test_migrated_cell_has_valid_id(self):
+        grid = MajorTomGrid(d=320, overlap=True)
+        new_cell = grid.migrate_cell_id("dr18zj1ntew")
+        self.assertEqual(len(new_cell.id()), 11)
+
+    def test_migrate_invalid_id(self):
+        grid = MajorTomGrid(d=320, overlap=True)
+        with self.assertRaises(ValueError):
+            grid.migrate_cell_id("short")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "majortom-eg"
-version = "0.3.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "geolib" },

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "majortom-eg"
-version = "0.1.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "geolib" },


### PR DESCRIPTION
## Summary

Fixes #4 -- the latitude/longitude grid was offset from the ESA reference implementation for grid distances where the division count is odd.

- Adds centering offsets (`_lat_offset`, `get_lon_offset`) so the equator and prime meridian always fall exactly on grid lines, matching ESA's `linspace + mod` approach
- Adds `migrate_cell_id()` method to map old geohash cell IDs to the updated grid
- Adds `TestESACompatibility` test suite verifying alignment with ESA across multiple grid distances (5km, 10km, 50km, 100km)
- Bumps version to 1.0.0 (breaking change: grid cell positions shift for odd division counts)

## Test plan

- [x] All 15 tests pass (7 existing + 4 ESA compatibility + 4 migration)
- [x] ESA compatibility verified: latitudes and longitudes match `linspace + mod` output to within 1e-10 degrees
- [x] Equator and prime meridian confirmed as grid lines for distances 5, 7, 10, 13, 50, 100 km
- [x] `migrate_cell_id` confirmed: new cell geometry contains the decoded centroid of old cell IDs
- [x] Existing `cell_from_id` and `cell_lookup` tests still pass with updated grid


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core grid indexing/placement by introducing latitude/longitude centering offsets, which shifts generated cell geometries and geohash IDs (breaking behavior). Adds migration support, but downstream consumers relying on stable cell boundaries/IDs may still be impacted.
> 
> **Overview**
> Aligns `MajorTomGrid` cell placement with ESA’s reference (`linspace`/`mod`) by adding centering offsets (`_lat_offset`, `get_lon_offset`) and using them throughout row/column coordinate generation and `cell_from_id` lookup.
> 
> Introduces `migrate_cell_id()` to map prior-version cell IDs onto the new grid, expands tests with an ESA compatibility suite plus migration assertions, and bumps package version to `1.0.0` (also updating lock metadata).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c42df0188c63a7de004be42bd2eb11602bbf355f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->