### PR TITLE
feat: parallelize generate_grid_cells via ProcessPoolExecutor

### DIFF
--- a/src/majortom_eg/MajorTom.py
+++ b/src/majortom_eg/MajorTom.py
@@ -1,11 +1,12 @@
 import numpy as np
 import shapely.geometry
 from shapely.geometry import Polygon
+from shapely import prepare
 from geolib import geohash
+from concurrent.futures import ProcessPoolExecutor
 
 
 class GridCell:
-
     def __init__(self, geom: shapely.geometry.Polygon, is_primary: bool = True):
         self.geom = geom
         self.is_primary = is_primary
@@ -15,13 +16,89 @@ class GridCell:
         return self._id
 
 
+def _process_row(args):
+    """Process a single row of grid cells. Module-level for pickling support."""
+    (
+        row_idx,
+        lat_spacing,
+        lat_offset,
+        earth_radius,
+        D,
+        overlap,
+        min_lon,
+        max_lon,
+        polygon_wkt,
+    ) = args
+
+    lat = -90 + lat_offset + row_idx * lat_spacing
+
+    # Recompute lon_spacing/offset locally (avoids pickling the grid object)
+    lat_rad = np.radians(min(max(lat, -89), 89))
+    circumference = 2 * np.pi * earth_radius * np.cos(lat_rad)
+    n_cols = int(np.ceil(circumference / D))
+    lon_spacing = 360 / max(n_cols, 1)
+
+    n_cols_for_offset = round(360 / lon_spacing) if lon_spacing > 0 else 0
+    lon_offset_val = lon_spacing / 2 if n_cols_for_offset % 2 else 0
+
+    start_col = int(np.floor((min_lon + 180 - lon_offset_val) / lon_spacing))
+    end_col = int(np.ceil((max_lon + 180 - lon_offset_val) / lon_spacing))
+
+    def col_lon(col_idx):
+        return -180 + lon_offset_val + col_idx * lon_spacing
+
+    while col_lon(start_col) > min_lon + 1e-10:
+        start_col -= 1
+    while col_lon(end_col) < max_lon - 1e-10:
+        end_col += 1
+
+    # Deserialize polygon once per worker call and prepare for fast intersection
+    polygon = shapely.from_wkt(polygon_wkt)
+    prepare(polygon)
+
+    results = []
+    for col_idx in range(start_col, end_col + 1):
+        lon = col_lon(col_idx)
+        primary_cell_polygon = Polygon(
+            [
+                [lon, lat],
+                [lon + lon_spacing, lat],
+                [lon + lon_spacing, lat + lat_spacing],
+                [lon, lat + lat_spacing],
+            ]
+        )
+
+        if overlap:
+            overlap_lon = lon + lon_spacing / 2
+            overlap_lat = lat + lat_spacing / 2
+            overlap_cell_polygon = Polygon(
+                [
+                    [overlap_lon, overlap_lat],
+                    [overlap_lon + lon_spacing, overlap_lat],
+                    [overlap_lon + lon_spacing, overlap_lat + lat_spacing],
+                    [overlap_lon, overlap_lat + lat_spacing],
+                ]
+            )
+
+            if primary_cell_polygon.intersects(polygon):
+                results.append(GridCell(primary_cell_polygon, is_primary=True))
+            if overlap_cell_polygon.intersects(polygon):
+                results.append(GridCell(overlap_cell_polygon, is_primary=False))
+        else:
+            if primary_cell_polygon.intersects(polygon):
+                results.append(GridCell(primary_cell_polygon, is_primary=True))
+
+    return results
+
+
 class MajorTomGrid:
-    def __init__(self, d: int = 320, overlap=True):
+    def __init__(self, d: int = 320, overlap=True, max_workers: int | None = None):
         if d <= 0:
             raise ValueError("Grid spacing must be positive")
         self.D = d
         self.earth_radius = 6378137
         self.overlap = overlap
+        self.max_workers = max_workers
         self.row_count = max(2, np.ceil(np.pi * self.earth_radius / self.D))
         self.lat_spacing = self.get_lat_spacing()
         self._lat_offset = self.lat_spacing / 2 if int(self.row_count) % 2 else 0
@@ -58,46 +135,34 @@ class MajorTomGrid:
         while self.get_row_lat(end_row) < max_lat - 1e-10:
             end_row += 1
 
-        for row_idx in range(start_row, end_row + 1):
-            lat = self.get_row_lat(row_idx)
-            lon_spacing = self.get_lon_spacing(lat)
-            lon_offset = self.get_lon_offset(lon_spacing)
+        row_indices = list(range(start_row, end_row + 1))
+        polygon_wkt = shapely.to_wkt(polygon)
 
-            start_col = int(np.floor((min_lon + 180 - lon_offset) / lon_spacing))
-            end_col = int(np.ceil((max_lon + 180 - lon_offset) / lon_spacing))
+        # Build args for each row
+        row_args = [
+            (
+                row_idx,
+                self.lat_spacing,
+                self._lat_offset,
+                self.earth_radius,
+                self.D,
+                self.overlap,
+                min_lon,
+                max_lon,
+                polygon_wkt,
+            )
+            for row_idx in row_indices
+        ]
 
-            while self.get_col_lon(start_col, lon_spacing, lon_offset) > min_lon + 1e-10:
-                start_col -= 1
-            while self.get_col_lon(end_col, lon_spacing, lon_offset) < max_lon - 1e-10:
-                end_col += 1
+        # Sequential execution (default / original behaviour)
+        if self.max_workers is None:
+            for args in row_args:
+                yield from _process_row(args)
+            return
 
-            for col_idx in range(start_col, end_col + 1):
-                lon = self.get_col_lon(col_idx, lon_spacing, lon_offset)
-                primary_cell_polygon = Polygon([
-                    [lon, lat],
-                    [lon + lon_spacing, lat],
-                    [lon + lon_spacing, lat + self.lat_spacing],
-                    [lon, lat + self.lat_spacing]
-                ])
-
-                if self.overlap:
-                    overlap_lon = lon + lon_spacing/2
-                    overlap_lat = lat + self.lat_spacing/2
-                    overlap_cell_polygon = Polygon([
-                        [overlap_lon, overlap_lat],
-                        [overlap_lon + lon_spacing, overlap_lat],
-                        [overlap_lon + lon_spacing, overlap_lat + self.lat_spacing],
-                        [overlap_lon, overlap_lat + self.lat_spacing]
-                    ])
-
-                    if primary_cell_polygon.intersects(polygon):
-                        yield GridCell(primary_cell_polygon, is_primary=True)
-                    if overlap_cell_polygon.intersects(polygon):
-                        yield GridCell(overlap_cell_polygon, is_primary=False)
-                else:
-                    if primary_cell_polygon.intersects(polygon):
-                        yield GridCell(primary_cell_polygon, is_primary=True)
-
+        with ProcessPoolExecutor(max_workers=self.max_workers) as executor:
+            for row_cells in executor.map(_process_row, row_args):
+                yield from row_cells
 
     def cell_from_id(self, cell_id: str) -> GridCell:
         search_id = cell_id[:11] if len(cell_id) > 11 else cell_id
@@ -110,22 +175,30 @@ class MajorTomGrid:
 
         half_lat = self.lat_spacing / 2
         for row_offset in (-1, 0, 1):
-            row_idx = int(np.floor((center_lat + 90 - self._lat_offset) / self.lat_spacing)) + row_offset
+            row_idx = (
+                int(np.floor((center_lat + 90 - self._lat_offset) / self.lat_spacing))
+                + row_offset
+            )
             row_lat = self.get_row_lat(row_idx)
             lon_spacing = self.get_lon_spacing(row_lat)
             lon_offset = self.get_lon_offset(lon_spacing)
             half_lon = lon_spacing / 2
 
             for col_offset in (-1, 0, 1):
-                col_idx = int(np.floor((center_lon + 180 - lon_offset) / lon_spacing)) + col_offset
+                col_idx = (
+                    int(np.floor((center_lon + 180 - lon_offset) / lon_spacing))
+                    + col_offset
+                )
                 cell_lon = self.get_col_lon(col_idx, lon_spacing, lon_offset)
 
-                primary = Polygon([
-                    [cell_lon, row_lat],
-                    [cell_lon + lon_spacing, row_lat],
-                    [cell_lon + lon_spacing, row_lat + self.lat_spacing],
-                    [cell_lon, row_lat + self.lat_spacing],
-                ])
+                primary = Polygon(
+                    [
+                        [cell_lon, row_lat],
+                        [cell_lon + lon_spacing, row_lat],
+                        [cell_lon + lon_spacing, row_lat + self.lat_spacing],
+                        [cell_lon, row_lat + self.lat_spacing],
+                    ]
+                )
                 candidate = GridCell(primary, is_primary=True)
                 if candidate.id() == search_id:
                     return candidate
@@ -133,12 +206,14 @@ class MajorTomGrid:
                 if self.overlap:
                     overlap_lon = cell_lon + half_lon
                     overlap_lat = row_lat + half_lat
-                    overlap_poly = Polygon([
-                        [overlap_lon, overlap_lat],
-                        [overlap_lon + lon_spacing, overlap_lat],
-                        [overlap_lon + lon_spacing, overlap_lat + self.lat_spacing],
-                        [overlap_lon, overlap_lat + self.lat_spacing],
-                    ])
+                    overlap_poly = Polygon(
+                        [
+                            [overlap_lon, overlap_lat],
+                            [overlap_lon + lon_spacing, overlap_lat],
+                            [overlap_lon + lon_spacing, overlap_lat + self.lat_spacing],
+                            [overlap_lon, overlap_lat + self.lat_spacing],
+                        ]
+                    )
                     overlap_cell = GridCell(overlap_poly, is_primary=False)
                     if overlap_cell.id() == search_id:
                         return overlap_cell
@@ -164,10 +239,12 @@ class MajorTomGrid:
         col_idx = int(np.floor((lon + 180 - lon_offset) / lon_spacing))
         cell_lon = self.get_col_lon(col_idx, lon_spacing, lon_offset)
 
-        cell_polygon = Polygon([
-            [cell_lon, row_lat],
-            [cell_lon + lon_spacing, row_lat],
-            [cell_lon + lon_spacing, row_lat + self.lat_spacing],
-            [cell_lon, row_lat + self.lat_spacing],
-        ])
+        cell_polygon = Polygon(
+            [
+                [cell_lon, row_lat],
+                [cell_lon + lon_spacing, row_lat],
+                [cell_lon + lon_spacing, row_lat + self.lat_spacing],
+                [cell_lon, row_lat + self.lat_spacing],
+            ]
+        )
         return GridCell(cell_polygon, is_primary=True)

--- a/src/majortom_eg/__init__.py
+++ b/src/majortom_eg/__init__.py
@@ -1,3 +1,7 @@
 # SPDX-FileCopyrightText: 2024-present Earth Genome <info@earthgenome.org>
 #
 # SPDX-License-Identifier: MIT
+
+from majortom_eg.MajorTom import GridCell, MajorTomGrid
+
+__all__ = ["GridCell", "MajorTomGrid"]

--- a/tests/test_major_tom_grid.py
+++ b/tests/test_major_tom_grid.py
@@ -625,6 +625,55 @@ class TestMigrateCellId(unittest.TestCase):
         with self.assertRaises(ValueError):
             grid.migrate_cell_id("short")
 
+class TestParallelGridCells(unittest.TestCase):
+    """Verify parallel generate_grid_cells matches sequential results."""
+
+    def _assert_cells_equal(self, cells_seq, cells_par):
+        self.assertEqual(len(cells_seq), len(cells_par),
+            "Sequential and parallel should produce the same number of cells")
+
+        seq_ids = sorted(c.id() for c in cells_seq)
+        par_ids = sorted(c.id() for c in cells_par)
+        self.assertEqual(seq_ids, par_ids,
+            "Sequential and parallel should produce the same cell IDs")
+
+        seq_by_id = {c.id(): c for c in cells_seq}
+        par_by_id = {c.id(): c for c in cells_par}
+        for cell_id in seq_by_id:
+            self.assertTrue(
+                seq_by_id[cell_id].geom.equals_exact(par_by_id[cell_id].geom, 1e-10),
+                f"Geometry mismatch for cell {cell_id}")
+            self.assertEqual(
+                seq_by_id[cell_id].is_primary, par_by_id[cell_id].is_primary,
+                f"is_primary mismatch for cell {cell_id}")
+
+    def test_parallel_matches_sequential_with_overlap(self):
+        poly = shapely.geometry.shape(bigSouthampton)
+        grid_seq = MajorTomGrid(d=50000, overlap=True)
+        grid_par = MajorTomGrid(d=50000, overlap=True, max_workers=4)
+
+        cells_seq = list(grid_seq.generate_grid_cells(poly))
+        cells_par = list(grid_par.generate_grid_cells(poly))
+        self._assert_cells_equal(cells_seq, cells_par)
+
+    def test_parallel_matches_sequential_no_overlap(self):
+        poly = shapely.geometry.shape(bigSouthampton)
+        grid_seq = MajorTomGrid(d=50000, overlap=False)
+        grid_par = MajorTomGrid(d=50000, overlap=False, max_workers=4)
+
+        cells_seq = list(grid_seq.generate_grid_cells(poly))
+        cells_par = list(grid_par.generate_grid_cells(poly))
+        self._assert_cells_equal(cells_seq, cells_par)
+
+    def test_parallel_matches_sequential_large_polygon(self):
+        big_poly = Polygon([(-10, -10), (10, -10), (10, 10), (-10, 10)])
+        grid_seq = MajorTomGrid(d=50000, overlap=True)
+        grid_par = MajorTomGrid(d=50000, overlap=True, max_workers=4)
+
+        cells_seq = list(grid_seq.generate_grid_cells(big_poly))
+        cells_par = list(grid_par.generate_grid_cells(big_poly))
+        self._assert_cells_equal(cells_seq, cells_par)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description
When working with high-resolution or extensive geospatial datasets, grid generation and processing can become a significant CPU bottleneck. To help alleviate this, this PR introduces an optional multiprocessing feature to MajorTomGrid to speed up these workloads by leveraging multiple CPU cores. 
The system defaults to the original sequential behavior unless explicitly configured otherwise.

### Changes

- Extract _process_row() as a module-level function (required for pickling)
- Add optional max_workers parameter to MajorTomGrid (default None = sequential, preserving original behaviour)
- Use shapely.prepare() inside workers for faster intersection checks
- Add 3 tests verifying parallel output is identical to sequential
- Export MajorTomGrid and GridCell from majortom_eg package root 

### Example

```python
import time
from shapely.geometry import box
from majortom_eg import GridCell, MajorTomGrid

####### DEFAULT ###########
start = time.time()
grid = MajorTomGrid(d=30000, overlap=False, max_workers=None)

# GOES-19 bounding box (Americas)
my_aoi = box(
    -154.23379623735477,
    -78.55278531136662,
    4.233796237354759,
    78.55278531136662
)
# iterate of cells returned from generator
eg_cells = list(grid.generate_grid_cells(my_aoi))
end = time.time() - start
print(end) # 23.19 seconds


####### PARALLEL ###########

start_parallel = time.time()
grid_parallel = MajorTomGrid(d=30000, overlap=False, max_workers=8)

# iterate of cells returned from generator
eg_cells_parallel = list(grid_parallel.generate_grid_cells(my_aoi))
end_parallel = time.time() - start_parallel
print(end_parallel) # 5.377 seconds

sorted([cell.id() for cell in eg_cells]) == sorted([cell.id() for cell in eg_cells_parallel])
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces `ProcessPoolExecutor`-based multiprocessing in core grid generation, which can change performance characteristics and exposes new concurrency/pickling edge cases despite tests asserting identical outputs.
> 
> **Overview**
> `MajorTomGrid.generate_grid_cells` is refactored to optionally parallelize row processing via `ProcessPoolExecutor`, controlled by a new `max_workers` constructor arg (default `None` keeps sequential behavior).
> 
> Row work is moved into a picklable module-level `_process_row`, passing the AOI polygon via WKT and using `shapely.prepare()` inside workers to speed intersection checks.
> 
> Package exports are updated to re-export `MajorTomGrid`/`GridCell` from `majortom_eg`, and new tests assert parallel vs sequential cell IDs/geometry match for overlap/non-overlap and a larger polygon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 689a65edc74e5c3b58aab2aa74b918efc842e1cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->