### PR TITLE
chore: bootstrap ei-internal-docs integration

### DIFF
--- a/.github/workflows/notify-internal-docs.yml
+++ b/.github/workflows/notify-internal-docs.yml
@@ -1,0 +1,69 @@
+# Notify ei-internal-docs of changes that may need cross-repo doc updates.
+#
+# Installed by `scripts/rollout_universal_agents_md.py` from the EI internal
+# docs repo. To update, edit the template at:
+#     https://github.com/earth-genome/ei-internal-docs/blob/main/templates/notify-internal-docs.yml
+#
+# Required org secret: EI_DOCS_DISPATCH_TOKEN
+#   A fine-grained PAT with `Contents: read` and `Issues: write` on
+#   earth-genome/ei-internal-docs.
+#
+# What it does:
+#   On every push to the default branch, computes the list of changed paths
+#   in this commit and sends a `repository_dispatch` event of type
+#   `component-updated` to ei-internal-docs. The listener there decides
+#   whether to open a "Sync needed" issue based on watched_paths in
+#   repos.yaml.
+
+name: Notify ei-internal-docs
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - dev
+      - production
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute changed paths since previous commit
+        id: changes
+        run: |
+          if [ -z "${{ github.event.before }}" ] || [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            CHANGED="(initial push)"
+          else
+            CHANGED=$(git --no-pager diff --name-only "${{ github.event.before }}" "${{ github.event.after }}" 2>/dev/null | head -100 | tr '\n' ',' | sed 's/,$//')
+          fi
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Send repository_dispatch to ei-internal-docs
+        env:
+          GH_TOKEN: ${{ secrets.EI_DOCS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "EI_DOCS_DISPATCH_TOKEN not set; skipping notification."
+            exit 0
+          fi
+          # Fall back gracefully if the dispatch endpoint rejects (e.g. token expired).
+          curl -fsSL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/earth-genome/ei-internal-docs/dispatches \
+            -d "$(jq -n \
+              --arg repo "${{ github.event.repository.name }}" \
+              --arg sha "${{ github.sha }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg url "${{ github.event.head_commit.url }}" \
+              --arg msg "${{ github.event.head_commit.message }}" \
+              --arg changed "${{ steps.changes.outputs.changed }}" \
+              '{event_type:"component-updated", client_payload:{repo:$repo, sha:$sha, actor:$actor, branch:$branch, url:$url, message:$msg, changed_paths:$changed}}')" \
+            || echo "Dispatch failed (non-fatal); ei-internal-docs nightly sync will catch this."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+<!-- BEGIN ei-internal-docs stanza -->
+## Org-wide context (EarthIndex)
+
+This repo is part of the **EarthIndex platform**. Cross-cutting context lives
+in [`earth-genome/ei-internal-docs`](https://github.com/earth-genome/ei-internal-docs).
+Read it before architectural work. The repo is private; agents need `gh auth`
+or a `GITHUB_TOKEN` with read access to fetch.
+
+- **This project's central entry:** https://github.com/earth-genome/ei-internal-docs/blob/main/projects/majortom/overview.md
+- **System architecture:** https://github.com/earth-genome/ei-internal-docs/blob/main/architecture/overview.md
+- **Data flow:** https://github.com/earth-genome/ei-internal-docs/blob/main/architecture/data-flow.md
+- **Single-fetch context bundle (Phase 3):** https://raw.githubusercontent.com/earth-genome/ei-internal-docs/main/dist/ei-context.md
+- **Doc contract:** https://github.com/earth-genome/ei-internal-docs/blob/main/DOC-CONTRACT.md
+
+When you make changes here that affect architecture, public APIs, env vars,
+infra, or data flow, **also open a PR in `ei-internal-docs`** updating the
+relevant section. The doc steward (`@tingold`) will review.
+<!-- END ei-internal-docs stanza -->
+


### PR DESCRIPTION
Bootstraps the integration with `earth-genome/ei-internal-docs` (Phase 2).

What this PR does:

1. Adds the EI internal-docs **Org-wide context** stanza to `AGENTS.md` so any agent (Claude, Cursor, Codex, etc.) started in this repo discovers the central platform docs without prompting.
2. Adds `.github/workflows/notify-internal-docs.yml` which sends a `repository_dispatch` event to `ei-internal-docs` on every push to the default branch. The listener there decides whether the change needs a doc update based on the `watched_paths` defined in `repos.yaml`.

**Required org secret:** `EI_DOCS_DISPATCH_TOKEN` (fine-grained PAT with `Contents: read` and `Issues: write` on `earth-genome/ei-internal-docs`). If the secret is missing the workflow no-ops gracefully.

Generated by [`scripts/rollout_universal_agents_md.py`](https://github.com/earth-genome/ei-internal-docs/blob/main/scripts/rollout_universal_agents_md.py). Re-running the script is idempotent — it will only update if the stanza or workflow has drifted from the template.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a GitHub Actions workflow and a docs guidance stanza, with no runtime/app code changes; main risk is misconfigured/expired dispatch token causing missed notifications.
> 
> **Overview**
> Adds an `AGENTS.md` *org-wide context* stanza that points contributors/agents to the central `earth-genome/ei-internal-docs` documentation and instructs opening doc PRs when changes affect architecture/APIs/infra.
> 
> Introduces a new GitHub Actions workflow (`.github/workflows/notify-internal-docs.yml`) that, on pushes to mainline branches, computes changed paths and sends a `repository_dispatch` (`component-updated`) to `ei-internal-docs`, gracefully no-oping if `EI_DOCS_DISPATCH_TOKEN` is missing or the dispatch fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5f6f8474040dad4a4431882b2c42a49fa8880d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->