### PR TITLE
chore: bootstrap ei-internal-docs integration

### DIFF
--- a/.github/workflows/notify-internal-docs.yml
+++ b/.github/workflows/notify-internal-docs.yml
@@ -32,6 +32,10 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Compute changed paths since previous commit
         id: changes
         run: |


### PR DESCRIPTION
Bootstraps the integration with `earth-genome/ei-internal-docs` (Phase 2).

What this PR does:

1. Adds the EI internal-docs **Org-wide context** stanza to `AGENTS.md` so any agent (Claude, Cursor, Codex, etc.) started in this repo discovers the central platform docs without prompting.
2. Adds `.github/workflows/notify-internal-docs.yml` which sends a `repository_dispatch` event to `ei-internal-docs` on every push to the default branch. The listener there decides whether the change needs a doc update based on the `watched_paths` defined in `repos.yaml`.

**Required org secret:** `EI_DOCS_DISPATCH_TOKEN` (fine-grained PAT with `Contents: read` and `Issues: write` on `earth-genome/ei-internal-docs`). If the secret is missing the workflow no-ops gracefully.

Generated by [`scripts/rollout_universal_agents_md.py`](https://github.com/earth-genome/ei-internal-docs/blob/main/scripts/rollout_universal_agents_md.py). Re-running the script is idempotent — it will only update if the stanza or workflow has drifted from the template.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk GitHub Actions change that just checks out full git history so the workflow can compute changed paths reliably before dispatching the notification event.
> 
> **Overview**
> Updates the `notify-internal-docs` GitHub Actions workflow to `actions/checkout@v4` with `fetch-depth: 0` so `git diff` can correctly compute changed paths between `github.event.before` and `github.event.after` prior to sending the `repository_dispatch` payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a40be0b3c93cf7bc5937af14da86f513fa8c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->